### PR TITLE
Make sure to have a consistent default logo, the banner logo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ Makefile.default:
 translations:
 	cd po && $(MAKE)
 
-logos-all:
-	find ./logos -type f > logo_config
+logos-all:	logo_config
+	find ./logos -type f -a ! -name banner.logo -a ! -name classic.logo >> logo_config
 	$(MAKE) all
 
 logo_config:


### PR DESCRIPTION
When using the 'logos-all' Makefile target, the find command would return
the list of logos to be included in an arbitrary order, and since the first
logo becomes the default, it lead to an unpredictable default output.
