### PR TITLE
Add minimal support for arm64 aka aarch64

### DIFF
--- a/libsysinfo-0.2.2/Linux/Makefile
+++ b/libsysinfo-0.2.2/Linux/Makefile
@@ -6,6 +6,9 @@ endif
 ifneq (,$(findstring arm,$(ARCH)))
    ARCH := arm
 endif
+ifneq (,$(findstring aarch64,$(ARCH)))
+   ARCH := arm
+endif
 ifneq (,$(findstring sh,$(ARCH)))
    ARCH := sh
 endif


### PR DESCRIPTION
This adds minimal support for ARM's 64-bit architecture called either `arm64` or `aarch64`.

According bug report in Debian: https://bugs.debian.org/791929
