### PR TITLE
Fix broken sysctl() calls on FreeBSD (64-bit)

### DIFF
--- a/libsysinfo-0.2.2/FreeBSD/cpuinfo_bsd.c
+++ b/libsysinfo-0.2.2/FreeBSD/cpuinfo_bsd.c
@@ -16,8 +16,8 @@ extern float external_bogomips(void);
 
 int get_cpu_info(struct cpu_info_type *cpu_info) {
 
-   int val_int;
-   int val_len;
+   size_t val_int = 0;
+   size_t val_len = 0;
 
    char val_str[BUFSIZ];
 

--- a/libsysinfo-0.2.2/FreeBSD/cpuinfo_bsd.c
+++ b/libsysinfo-0.2.2/FreeBSD/cpuinfo_bsd.c
@@ -16,8 +16,8 @@ extern float external_bogomips(void);
 
 int get_cpu_info(struct cpu_info_type *cpu_info) {
 
-   size_t val_int = 0;
-   size_t val_len = 0;
+   size_t val_int=0;
+   size_t val_len=0;
 
    char val_str[BUFSIZ];
 

--- a/libsysinfo-0.2.2/FreeBSD/sysinfo_bsd.c
+++ b/libsysinfo-0.2.2/FreeBSD/sysinfo_bsd.c
@@ -88,8 +88,8 @@ long long get_mem_size(void) {
     int ctl_ram[] = { CTL_HW, HW_PHYSMEM };
     long long mem_size=0;
 
-    size_t val_int;
-    size_t val_len;
+    size_t val_int=0;
+    size_t val_len=0;
    
     val_len = sizeof(val_int);
     if (sysctl(ctl_ram, SIZE(ctl_ram), &val_int, &val_len,0,0))

--- a/libsysinfo-0.2.2/FreeBSD/sysinfo_bsd.c
+++ b/libsysinfo-0.2.2/FreeBSD/sysinfo_bsd.c
@@ -88,8 +88,8 @@ long long get_mem_size(void) {
     int ctl_ram[] = { CTL_HW, HW_PHYSMEM };
     long long mem_size=0;
 
-    int val_int;
-    int val_len;
+    size_t val_int;
+    size_t val_len;
    
     val_len = sizeof(val_int);
     if (sysctl(ctl_ram, SIZE(ctl_ram), &val_int, &val_len,0,0))


### PR DESCRIPTION
Building the application on FreeBSD 10.3 (64-bit) causes the following warnings:

```
gcc -Wall -O2 -I.. -o cpuinfo.o -c cpuinfo_bsd.c
cpuinfo_bsd.c: In function 'get_cpu_info':
cpuinfo_bsd.c:28:4: warning: passing argument 4 of 'sysctl' from incompatible pointer type [enabled by default]
    if (sysctl(ctl_cpu, SIZE(ctl_cpu), val_str, &val_len,0,0))
    ^
In file included from cpuinfo_bsd.c:7:0:
/usr/include/sys/sysctl.h:804:5: note: expected 'size_t *' but argument is of type 'int *'
 int sysctl(const int *, u_int, void *, size_t *, const void *, size_t);
     ^
cpuinfo_bsd.c:34:4: warning: passing argument 4 of 'sysctl' from incompatible pointer type [enabled by default]
    if (sysctl(ctl_ncpu, SIZE(ctl_ncpu), &val_int, &val_len,0,0))
    ^
In file included from cpuinfo_bsd.c:7:0:
/usr/include/sys/sysctl.h:804:5: note: expected 'size_t *' but argument is of type 'int *'
 int sysctl(const int *, u_int, void *, size_t *, const void *, size_t);
     ^
gcc -Wall -O2 -I.. -c sysinfo_bsd.c
sysinfo_bsd.c: In function 'get_mem_size':
sysinfo_bsd.c:95:5: warning: passing argument 4 of 'sysctl' from incompatible pointer type [enabled by default]
     if (sysctl(ctl_ram, SIZE(ctl_ram), &val_int, &val_len,0,0))
     ^
In file included from sysinfo_bsd.c:24:0:
/usr/include/sys/sysctl.h:804:5: note: expected 'size_t *' but argument is of type 'int *'
 int sysctl(const int *, u_int, void *, size_t *, const void *, size_t);
```

Indeed [sysctl(3)](https://www.freebsd.org/cgi/man.cgi?sysctl%283%29) states that the parameters should be `size_t` and not `int`. This leads to various issues on a 64-bit platform, such as the number of CPUs or system memory size showing zero.

Fixed it by initialising the values to zero and by changing type to `size_t`.
