### PR TITLE
Require -lintl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ PROGNAME = linux_logo
 #   LDFLAGS += -lintl
 #endif
 
+ifeq ($(OS),FreeBSD)
+    LDFLAGS += -lintl
+endif
+
 #
 # Installation location
 #


### PR DESCRIPTION
On FreeBSD, -lintl is required to link against libintl.

If missing, gcc linker raises undefined reference to libintl_gettext.

Reference:
https://www.gnu.org/software/gettext/FAQ.html#integrating_undefined
