### PR TITLE
Sort input file list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ translations:
 	cd po && $(MAKE)
 
 logos-all:	logo_config
-	find ./logos -type f -a ! -name banner.logo -a ! -name classic.logo >> logo_config
+	find ./logos -type f -a ! -name banner.logo -a ! -name classic.logo | sort >> logo_config
 	$(MAKE) all
 
 logo_config:


### PR DESCRIPTION
Sort input file list
so that `logo_config` and `load_logos.h` build in a reproducible way
in spite of indeterministic filesystem readdir order

See https://reproducible-builds.org/ for why this is good.